### PR TITLE
Add `jsonFallback` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@ Currently the following types are supported:
 - URL objects
 - URLSearchParams objects
 
-if `options.instanceAsObject` is set to `true`, other objects are turned into
-plain object.
+if `options.instanceAsObject` is set to `true`, other objects are turned into plain object.
 
-```js
+```ts
 import { deepEqual, throws } from 'assert';
 
 import { valueToEstree } from 'estree-util-value-to-estree';
@@ -216,7 +215,7 @@ class Point {
 throws(() => valueToEstree(new Point(2, 3)));
 
 // `instanceAsObject: true` treats them as plain objects.
-deepEqual(valueToEstree(new Point(2, 3), {instanceAsObject: true}), {
+deepEqual(valueToEstree(new Point(2, 3), { instanceAsObject: true }), {
   type: 'ObjectExpression',
   properties: [
     {

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Currently the following types are supported:
 - URL objects
 - URLSearchParams objects
 
-if `options.jsonFallback` is set to `true`, other values are passed through
-`JSON.parse(JSON.stringify(value))`.
+if `options.instanceAsObject` is set to `true`, other objects are turned into
+plain object.
 
 ```js
 import { deepEqual, throws } from 'assert';
@@ -212,9 +212,11 @@ class Point {
   }
 }
 
+// Normally complex objects throw.
 throws(() => valueToEstree(new Point(2, 3)));
 
-deepEqual(valueToEstree(new Point(2, 3), {
+// `instanceAsObject: true` treats them as plain objects.
+deepEqual(valueToEstree(new Point(2, 3), {instanceAsObject: true}), {
   type: 'ObjectExpression',
   properties: [
     {
@@ -236,7 +238,7 @@ deepEqual(valueToEstree(new Point(2, 3), {
       value: { type: 'Literal', value: 3, raw: '3' },
     },
   ],
-}));
+});
 ```
 
 [codecov badge]:

--- a/README.md
+++ b/README.md
@@ -36,8 +36,11 @@ Currently the following types are supported:
 - URL objects
 - URLSearchParams objects
 
+if `options.jsonFallback` is set to `true`, other values are passed through
+`JSON.parse(JSON.stringify(value))`.
+
 ```js
-import { deepEqual } from 'assert';
+import { deepEqual, throws } from 'assert';
 
 import { valueToEstree } from 'estree-util-value-to-estree';
 
@@ -199,6 +202,41 @@ deepEqual(result, {
     },
   ],
 });
+
+class Point {
+  line: number;
+  column: number;
+  constructor(line: number, column: number) {
+    this.line = line;
+    this.column = column;
+  }
+}
+
+throws(() => valueToEstree(new Point(2, 3)));
+
+deepEqual(valueToEstree(new Point(2, 3), {
+  type: 'ObjectExpression',
+  properties: [
+    {
+      type: 'Property',
+      method: false,
+      shorthand: false,
+      computed: false,
+      kind: 'init',
+      key: { type: 'Literal', value: 'line', raw: '"line"' },
+      value: { type: 'Literal', value: 2, raw: '2' },
+    },
+    {
+      type: 'Property',
+      method: false,
+      shorthand: false,
+      computed: false,
+      kind: 'init',
+      key: { type: 'Literal', value: 'column', raw: '"column"' },
+      value: { type: 'Literal', value: 3, raw: '3' },
+    },
+  ],
+}));
 ```
 
 [codecov badge]:

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -467,9 +467,7 @@ describe('valueToEstree', () => {
     const point = new Point(2, 3);
 
     // @ts-expect-error This tests an unsupported value.
-    expect(() => valueToEstree(point)).toThrow(
-      new TypeError('Unsupported value: [object Object]'),
-    );
+    expect(() => valueToEstree(point)).toThrow(new TypeError('Unsupported value: [object Object]'));
 
     // @ts-expect-error This tests an unsupported value.
     expect(valueToEstree(point, { jsonFallback: true })).toStrictEqual({

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -443,18 +443,16 @@ describe('valueToEstree', () => {
   });
 
   it('should throw for unsupported values', () => {
-    // @ts-expect-error This tests an unsupported value.
     expect(() => valueToEstree(() => null)).toThrow(new TypeError('Unsupported value: () => null'));
     class A {
       a = '';
     }
-    // @ts-expect-error This tests an unsupported value.
     expect(() => valueToEstree(new A())).toThrow(
       new TypeError('Unsupported value: [object Object]'),
     );
   });
 
-  it('should transform to json on unsupported values w/ `jsonFallback`', () => {
+  it('should transform to json on unsupported values w/ `instanceAsObject`', () => {
     class Point {
       line: number;
       column: number;
@@ -466,11 +464,9 @@ describe('valueToEstree', () => {
 
     const point = new Point(2, 3);
 
-    // @ts-expect-error This tests an unsupported value.
     expect(() => valueToEstree(point)).toThrow(new TypeError('Unsupported value: [object Object]'));
 
-    // @ts-expect-error This tests an unsupported value.
-    expect(valueToEstree(point, { jsonFallback: true })).toStrictEqual({
+    expect(valueToEstree(point, { instanceAsObject: true })).toStrictEqual({
       type: 'ObjectExpression',
       properties: [
         {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { Value, valueToEstree } from '.';
+import { valueToEstree } from '.';
 
 describe('valueToEstree', () => {
   it('should handle undefined', () => {
@@ -111,7 +111,7 @@ describe('valueToEstree', () => {
   it('should handle maps', () => {
     expect(
       valueToEstree(
-        new Map<Value, Value>([
+        new Map<unknown, unknown>([
           [{}, 42],
           [42, {}],
         ]),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -453,4 +453,47 @@ describe('valueToEstree', () => {
       new TypeError('Unsupported value: [object Object]'),
     );
   });
+
+  it('should transform to json on unsupported values w/ `jsonFallback`', () => {
+    class Point {
+      line: number;
+      column: number;
+      constructor(line: number, column: number) {
+        this.line = line;
+        this.column = column;
+      }
+    }
+
+    const point = new Point(2, 3);
+
+    // @ts-expect-error This tests an unsupported value.
+    expect(() => valueToEstree(point)).toThrow(
+      new TypeError('Unsupported value: [object Object]'),
+    );
+
+    // @ts-expect-error This tests an unsupported value.
+    expect(valueToEstree(point, { jsonFallback: true })).toStrictEqual({
+      type: 'ObjectExpression',
+      properties: [
+        {
+          type: 'Property',
+          method: false,
+          shorthand: false,
+          computed: false,
+          kind: 'init',
+          key: { type: 'Literal', value: 'line', raw: '"line"' },
+          value: { type: 'Literal', value: 2, raw: '2' },
+        },
+        {
+          type: 'Property',
+          method: false,
+          shorthand: false,
+          computed: false,
+          kind: 'init',
+          key: { type: 'Literal', value: 'column', raw: '"column"' },
+          value: { type: 'Literal', value: 3, raw: '3' },
+        },
+      ],
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ export interface Options {
  * @param options - Additional options to configure the output.
  * @returns The ESTree node.
  */
-export function valueToEstree(value?: Value, options?: Options): Expression {
+export function valueToEstree(value?: unknown, options: Options = {}): Expression {
   if (value === undefined) {
     return { type: 'Identifier', name: 'undefined' };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,9 @@ type ValueSet = Set<Value>;
 type ValueMap = Map<Value, Value>;
 
 export interface Options {
+  /**
+   * If true, treat objects that have a prototype as plain objects.
+   */
   instanceAsObject?: boolean;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ type ValueSet = Set<Value>;
 type ValueMap = Map<Value, Value>;
 
 export interface Options {
-  jsonFallback?: boolean;
+  instanceAsObject?: boolean;
 }
 
 /**
@@ -157,9 +157,10 @@ export function valueToEstree(value?: unknown, options: Options = {}): Expressio
       arguments: [valueToEstree(String(value))],
     };
   }
-  if (isPlainObject(value)) {
+  if (options.instanceAsObject || isPlainObject(value)) {
     return {
       type: 'ObjectExpression',
+      // @ts-expect-error: looks like an object.
       properties: Object.entries(value).map(([name, val]) => ({
         type: 'Property',
         method: false,
@@ -170,9 +171,6 @@ export function valueToEstree(value?: unknown, options: Options = {}): Expressio
         value: valueToEstree(val),
       })),
     };
-  }
-  if (options && options.jsonFallback) {
-    return valueToEstree(JSON.parse(JSON.stringify(value)));
   }
 
   throw new TypeError(`Unsupported value: ${String(value)}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,41 +9,6 @@ declare const URLSearchParams: typeof globalThis extends { URL: infer URLSearchP
   ? URLSearchParamsCtor
   : typeof import('url').URLSearchParams;
 
-/**
- * A value that can be serialized by `estree-util-from-value`.
- */
-export type Value =
-  | BigInt64Array
-  | BigUint64Array
-  | Date
-  | Float32Array
-  | Float64Array
-  | Int8Array
-  | Int16Array
-  | Int32Array
-  | RegExp
-  | Uint8Array
-  | Uint8ClampedArray
-  | Uint16Array
-  | Uint32Array
-  | URL
-  | URLSearchParams
-  | Value[]
-  | ValueMap
-  | ValueSet
-  | bigint
-  | boolean
-  | number
-  | string
-  | symbol
-  // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
-  | { [key: string]: Value }
-  | null
-  | undefined;
-
-type ValueSet = Set<Value>;
-type ValueMap = Map<Value, Value>;
-
 export interface Options {
   /**
    * If true, treat objects that have a prototype as plain objects.

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export interface Options {
  * Convert a value to an ESTree node
  *
  * @param value - The value to convert
- * @param options
+ * @param options - Additional options to configure the output.
  * @returns The ESTree node.
  */
 export function valueToEstree(value?: Value, options?: Options): Expression {

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,13 +44,18 @@ export type Value =
 type ValueSet = Set<Value>;
 type ValueMap = Map<Value, Value>;
 
+export interface Options {
+  jsonFallback?: boolean;
+}
+
 /**
  * Convert a value to an ESTree node
  *
  * @param value - The value to convert
+ * @param options
  * @returns The ESTree node.
  */
-export function valueToEstree(value?: Value): Expression {
+export function valueToEstree(value?: Value, options?: Options): Expression {
   if (value === undefined) {
     return { type: 'Identifier', name: 'undefined' };
   }
@@ -166,5 +171,9 @@ export function valueToEstree(value?: Value): Expression {
       })),
     };
   }
+  if (options && options.jsonFallback) {
+    return valueToEstree(JSON.parse(JSON.stringify(value)));
+  }
+
   throw new TypeError(`Unsupported value: ${String(value)}`);
 }


### PR DESCRIPTION
Actual use case:

- Acorn uses instances of classes for nodes
- This allows them to be serialized, instead of an error about `[object Object]`

Note:

- Naming is up for debate
- There is no tooling in this repo to format the project, but there are configuration files, meaning that prettier in my editor reformats everything I touch, and I can’t match your styleguide