### PR TITLE
Add support for serializing custom values

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ Convert a value to an [ESTree](https://github.com/estree/estree) node.
 - `preserveReferences` (boolean, default: `false`) — If true, preserve references to the same object
   found within the input. This also allows to serialize recursive structures. If needed, the
   resulting expression will be an iife.
-- `customSerialize` (Function) — A function to customize the serialization of a value. It accepts
-  the value to serialize as an argument. It must return the value serialized to an ESTree
-  expression. If nothing is returned, the value is processed by the builtin logic.
+- `replacer` (Function) — A function to customize the serialization of a value. It accepts the value
+  to serialize as an argument. It must return the value serialized to an ESTree expression. If
+  nothing is returned, the value is processed by the builtin logic.
 
 ## Examples
 
@@ -183,8 +183,8 @@ console.log(result)
 
 ### Serialize custom values
 
-You can customize the serialization of values using `customSerialize`. For example, to serialize a
-custom class:
+You can customize the serialization of values using the `replacer` option. For example, to serialize
+a custom class:
 
 ```ts
 import { valueToEstree } from 'estree-util-value-to-estree'
@@ -203,7 +203,7 @@ class Point {
 const point = new Point(2, 3)
 
 const result = valueToEstree(point, {
-  customSerialize(value) {
+  replacer(value) {
     if (value instanceof Point) {
       return {
         type: 'NewExpression',

--- a/src/estree-util-value-to-estree.ts
+++ b/src/estree-util-value-to-estree.ts
@@ -294,7 +294,7 @@ export interface Options {
    *   The value serialized to an ESTree expression. If nothing is returned, the value is processed
    *   by the builtin logic.
    */
-  customSerialize?: (value: unknown) => Expression | undefined | void
+  replacer?: (value: unknown) => Expression | undefined | void
 }
 
 /**
@@ -434,7 +434,7 @@ export function valueToEstree(value: unknown, options: Options = {}): Expression
       value: val
     })
 
-    const estree = options?.customSerialize?.(val)
+    const estree = options?.replacer?.(val)
     if (estree) {
       customTrees.set(val, estree)
       return

--- a/src/test.ts
+++ b/src/test.ts
@@ -143,7 +143,7 @@ test('transform to json on unsupported values with `instanceAsObject`', () => {
   })
 })
 
-test('transform an unsupported value with customSerialize', () => {
+test('transform an unsupported value with replacer', () => {
   class Point {
     line: number
 
@@ -161,7 +161,7 @@ test('transform an unsupported value with customSerialize', () => {
     generate(
       valueToEstree([point, point], {
         preserveReferences: true,
-        customSerialize(value) {
+        replacer(value) {
           if (value instanceof Point) {
             return {
               type: 'NewExpression',
@@ -179,14 +179,14 @@ test('transform an unsupported value with customSerialize', () => {
   )
 })
 
-test('transform a function with customSerialize', () => {
+test('transform a function with replacer', () => {
   assert.deepEqual(
     generate(
       valueToEstree(
         { setTimeout },
         {
           preserveReferences: true,
-          customSerialize(value) {
+          replacer(value) {
             if (value === setTimeout) {
               return { type: 'Identifier', name: 'setTimeout' }
             }

--- a/src/test.ts
+++ b/src/test.ts
@@ -94,7 +94,7 @@ test('throw for cyclic references', () => {
   )
 })
 
-test('transform to json on unsupported values w/ `instanceAsObject`', () => {
+test('transform to json on unsupported values with `instanceAsObject`', () => {
   class Point {
     line: number
 
@@ -141,4 +141,59 @@ test('transform to json on unsupported values w/ `instanceAsObject`', () => {
       }
     ]
   })
+})
+
+test('transform an unsupported value with customSerialize', () => {
+  class Point {
+    line: number
+
+    column: number
+
+    constructor(line: number, column: number) {
+      this.line = line
+      this.column = column
+    }
+  }
+
+  const point = new Point(2, 3)
+
+  assert.deepEqual(
+    generate(
+      valueToEstree([point, point], {
+        preserveReferences: true,
+        customSerialize(value) {
+          if (value instanceof Point) {
+            return {
+              type: 'NewExpression',
+              callee: { type: 'Identifier', name: 'Point' },
+              arguments: [
+                { type: 'Literal', value: value.line },
+                { type: 'Literal', value: value.column }
+              ]
+            }
+          }
+        }
+      })
+    ),
+    '(($0 = new Point(2, 3)) => ([$0, $0]))()'
+  )
+})
+
+test('transform a function with customSerialize', () => {
+  assert.deepEqual(
+    generate(
+      valueToEstree(
+        { setTimeout },
+        {
+          preserveReferences: true,
+          customSerialize(value) {
+            if (value === setTimeout) {
+              return { type: 'Identifier', name: 'setTimeout' }
+            }
+          }
+        }
+      )
+    ),
+    '{\n  "setTimeout": setTimeout\n}'
+  )
 })


### PR DESCRIPTION
This change introduces a new option `replacer`. This is a function which accepts the value to serialize, and may return an ESTree expression to represent the value. If nothing is returned, the value is further processed by `valueToEstree`.